### PR TITLE
port changes from d3d8-wrapper

### DIFF
--- a/data/d3d9.ini
+++ b/data/d3d9.ini
@@ -1,3 +1,10 @@
 [MAIN]
-FPSLimit = 0
-ForceWindowedMode = 0
+FPSLimit = 0                                   // max fps (0: unlimited/off)
+FPSLimitMode = 1                               // 1: realtime (thread-lock)  -  2: accurate (sleep-yield)
+ForceWindowedMode = 0                          // activates forced windowed mode
+
+[FORCEWINDOWED]
+UsePrimaryMonitor = 0                          // move window to primary monitor
+CenterWindow = 1                               // center window on screen
+BorderlessFullscreen = 0                       // borderless fullscreen windowed mode
+AlwaysOnTop = 0                                // window stays always on top


### PR DESCRIPTION
* New config options FPSLimitMode, UsePrimaryMonitor, CenterWindow, BorderlessFullscreen, AlwaysOnTop
* Return E_FAIL on Direct3D9EnableMaximizedWindowedModeShim if the function does not exist (prior to Windows 8 it doesn't)
* Correct presentation parameters for windowed mode

Port these PR from d3d8-wrapper
- https://github.com/ThirteenAG/d3d8-wrapper/pull/2
- https://github.com/ThirteenAG/d3d8-wrapper/pull/3
- https://github.com/ThirteenAG/d3d8-wrapper/pull/4
- https://github.com/ThirteenAG/d3d8-wrapper/pull/5

**Note**: Code is basically copy-paste and untested besides building correctly so a game should be tested before merging.