### PR TITLE
correct return type E_FAIL -> NULL

### DIFF
--- a/source/dllmain.cpp
+++ b/source/dllmain.cpp
@@ -447,7 +447,7 @@ int WINAPI Direct3D9EnableMaximizedWindowedModeShim(BOOL mEnable)
 {
 	if (!m_pDirect3D9EnableMaximizedWindowedModeShim)
 	{
-		return E_FAIL;
+		return NULL;
 	}
 
 	return m_pDirect3D9EnableMaximizedWindowedModeShim(mEnable);


### PR DESCRIPTION
D3D9 seems to use int instead of HRESULT in D3D8