### PR TITLE
add new features

### DIFF
--- a/data/d3d9.ini
+++ b/data/d3d9.ini
@@ -4,13 +4,15 @@ FPSLimitMode = 2                               // 1: realtime (thread-lock) | 2:
 FullScreenRefreshRateInHz = 0                  // overrides refresh rate selected by directx
 DisplayFPSCounter = 0                          // displays fps and frametime on screen
 ForceWindowedMode = 0                          // activates forced windowed mode
+EnableHooks = 0                                // needed for DoNotNotifyOnTaskSwitch, might need for CaptureMouse
 
 [FORCEWINDOWED]
 UsePrimaryMonitor = 0                          // move window to primary monitor
 CenterWindow = 1                               // center window on screen
 AlwaysOnTop = 0                                // window stays always on top
 DoNotNotifyOnTaskSwitch = 0                    // window ignores focus loss
-ForceWindowStyle = 0                           // 1: borderless fullscreen | 2: window | 3: resizable window
+ForceWindowStyle = 0                           // 0: no change | 1: borderless fullscreen | 2: window | 3: resizable window | 4: no style
+CaptureMouse = 0                               // capture mouse to window
 
 [LAUNCHER]
 AppExe = 


### PR DESCRIPTION
**EnableHooks**=0/1 can explicitly disable/enable hooks, useful for troubleshooting potential compatibility issues

**ForceWindowStyle**=4 forces no style (as in removing style), useful if you want to play with original aspect ratio and not stretch as stretching does not work with some games (e.g. Sid Meier's Pirates!), or you could just prefer to play with black bars

**CaptureMouse**=1 captures mouse to window

For future it could be neat to add a feature "CreateBlackBarsWindow" to create just a totally black window that covers the screen and put it behind the game, so that window becomes the "black bars" when playing a 4:3 game on your 16:9 (or whatever) screen.

What I currently with 4:3 games and ForceWindowStyle=4, I simply open this image of a black square in Windows Photo Viewer and press F11 so it makes it a full screen slideshow and use that as the background for game. It is stupid but works, and more elegant solution baked in the wrapper would be nicer.
![black](https://github.com/user-attachments/assets/430083d5-0f6d-4216-be9b-30cb15c222f4)
